### PR TITLE
Use default name for powerdns secret in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ spec:
             groupName: acme.yourdomain.tld
             solverName: pdns
             config:
-              secretName: powerdns-secret
+              secretName: pdns-secret
               zoneName: example.com.
               apiUrl: https://powerndns.com
 ```


### PR DESCRIPTION
This avoids a bit of confusion when setting up with the examples in the README.
The default secret name in values is pdns-secret.