### PR TITLE
Add support for creating PSP and setting up its use

### DIFF
--- a/deploy/cert-manager-webhook-powerndns/templates/rbac.yaml
+++ b/deploy/cert-manager-webhook-powerndns/templates/rbac.yaml
@@ -121,3 +121,83 @@ subjects:
     kind: ServiceAccount
     name: {{ include "cert-manager-webhook-powerdns.fullname" . }}
     namespace: {{ .Release.Namespace }}
+{{- if .Values.podSecurityPolicy.enabled }}
+{{-   $psp_use_list = .Values.podSecurityPolicy.use }}
+{{-   if .Values.podSecurityPolicy.create }}
+{{-     $psp_use_list = append $psp_use_list "webhook-powerdns-restricted" }}
+---
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: webhook-powerdns-restricted
+  annotations:
+    seccomp.security.alpha.kubernetes.io/allowedProfileNames: 'docker/default,runtime/default'
+    apparmor.security.beta.kubernetes.io/allowedProfileNames: 'runtime/default'
+    apparmor.security.beta.kubernetes.io/defaultProfileName:  'runtime/default'
+spec:
+  privileged: false
+  # Required to prevent escalations to root.
+  allowPrivilegeEscalation: false
+  requiredDropCapabilities:
+    - ALL
+  # Allow core volume types.
+  volumes:
+    - 'configMap'
+    - 'emptyDir'
+    - 'projected'
+    - 'secret'
+    - 'downwardAPI'
+    - 'ephemeral'
+  hostNetwork: false
+  hostIPC: false
+  hostPID: false
+  runAsUser:
+    # Require the container to run without root privileges.
+    rule: 'MustRunAsNonRoot'
+  seLinux:
+    # This policy assumes the nodes are using AppArmor rather than SELinux.
+    rule: 'RunAsAny'
+  supplementalGroups:
+    rule: 'MustRunAs'
+    ranges:
+      # Forbid adding the root group.
+      - min: 1
+        max: 65535
+  fsGroup:
+    rule: 'MustRunAs'
+    ranges:
+      # Forbid adding the root group.
+      - min: 1
+        max: 65535
+  readOnlyRootFilesystem: false
+{{-  end }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "cert-manager-webhook-powerdns.fullname" . }}:psp-use
+  namespace: {{ .Release.Namespace }}
+rules:
+  - apiGroups: ["policy"]
+    resources: ["podsecuritypolicies"]
+    verbs: ["use"]
+    resourceNames:
+    {{- with $psp_use_list }}
+    - {{ . }}
+    {{- end }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "cert-manager-webhook-powerdns.fullname" . }}:psp-use
+  namespace: {{ .Release.Namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "cert-manager-webhook-powerdns.fullname" . }}:psp-use
+subjects:
+  - apiGroup: ""
+    kind: ServiceAccount
+    name: {{ include "cert-manager-webhook-powerdns.fullname" . }}
+    namespace: {{ .Release.Namespace }}
+{{ end }}

--- a/deploy/cert-manager-webhook-powerndns/values.yaml
+++ b/deploy/cert-manager-webhook-powerndns/values.yaml
@@ -27,6 +27,16 @@ service:
 secretName:
   - pdns-secret
 
+# enable the use of Pod Security Policies (PSPs)
+# either set `create` to true in order to create a new PSP with minimal persmissions 
+# or leave set to false and add a list of PSP names to `use` for the inclusion of existing
+# PSPs
+podSecurityPolicy:
+  # set to true to enable
+  enable: false
+  create: false
+  use: []
+
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little


### PR DESCRIPTION
The patch will create a restricted PodSecurityPolicy or set up the use of any existing one using the field `podSecurityPolicy`

```
# enable the use of Pod Security Policies (PSPs)
# either set `create` to true in order to create a new PSP with minimal persmissions 
# or leave set to false and add a list of PSP names to `use` for the inclusion of existing
# PSPs
podSecurityPolicy:
  # set to true to enable
  enable: false
  create: false
  use: []
´´´

I am fully aware that PSPs have been deprecated. But there are a lot of clusters that are not updated to 1.21 and theses PSPs help securing workloads today.