### PR TITLE
changed the certificate durations to canonical format

### DIFF
--- a/deploy/cert-manager-webhook-powerndns/templates/pki.yaml
+++ b/deploy/cert-manager-webhook-powerndns/templates/pki.yaml
@@ -29,7 +29,7 @@ metadata:
     heritage: {{ .Release.Service }}
 spec:
   secretName: {{ include "cert-manager-webhook-powerdns.rootCACertificate" . }}
-  duration: 43800h # 5y
+  duration: 43800h0m0s # 5y
   issuerRef:
     name: {{ include "cert-manager-webhook-powerdns.selfSignedIssuer" . }}
   commonName: "ca.cert-manager-webhook-powerdns.cert-manager"
@@ -67,7 +67,7 @@ metadata:
     heritage: {{ .Release.Service }}
 spec:
   secretName: {{ include "cert-manager-webhook-powerdns.servingCertificate" . }}
-  duration: 8760h # 1y
+  duration: 8760h0m0s # 1y
   issuerRef:
     name: {{ include "cert-manager-webhook-powerdns.rootCAIssuer" . }}
   dnsNames:


### PR DESCRIPTION
this prevents problems with ArgoCD, as it will be out-of-sync otherwise