### PR TITLE
Remove "ZoneName" config setting / added "Domain" config setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,6 @@ spec:
             config:
               zone: example.com # (Optional): When not provided the Zone will obtained by cert-manager's ResolvedZone
               secretName: pdns-secret
-              zoneName: example.com.
               apiUrl: https://powerndns.com
 ```
 
@@ -116,8 +115,7 @@ else they will have undetermined behaviour when used with cert-manager.
 **It is essential that you configure and run the test suite when creating a
 DNS01 webhook.**
 
-You need to replace `zoneName` parameter at `testdata/pdns/config.json` file with actual one.
-You also must encode your api token into base64 and put the hash into `testdata/pdns/pdns-secret.yml` file.
+You must encode your api token into base64 and put the hash into `testdata/pdns/pdns-secret.yml` file.
 
 You can then run the test suite with:
 

--- a/internal/pdns.go
+++ b/internal/pdns.go
@@ -1,5 +1,5 @@
 package internal
 
 type Config struct {
-	ApiKey, ZoneName, ServerName, ApiUrl, Zone string
+	ApiKey, ServerName, ApiUrl, Zone string
 }

--- a/internal/pdns.go
+++ b/internal/pdns.go
@@ -1,5 +1,5 @@
 package internal
 
 type Config struct {
-	ApiKey, ServerName, ApiUrl, Zone string
+	ApiKey, ServerName, ApiUrl, Zone, Domain string
 }

--- a/main.go
+++ b/main.go
@@ -76,7 +76,6 @@ type pdnsDNSProviderConfig struct {
 	//Email           string `json:"email"`
 	//APIKeySecretRef v1alpha1.SecretKeySelector `json:"apiKeySecretRef"`
 	SecretRef  string `json:"secretName"`
-	ZoneName   string `json:"zoneName"`
 	ServerName string `json:"server"`
 	ApiUrl     string `json:"apiUrl"`
 	Zone       string `json:"zone"`
@@ -109,7 +108,7 @@ func (c *pdnsDNSProviderSolver) Present(ch *v1alpha1.ChallengeRequest) error {
 	}
 
 	pdns := powerdns.NewClient(config.ApiUrl, config.ServerName, map[string]string{"X-API-Key": config.ApiKey}, nil)
-	//p_err := pdns.Records.Add(config.ZoneName, ch.ResolvedFQDN, powerdns.RRTypeTXT, 120, []string{key})
+	//p_err := pdns.Records.Add(config.Zone, ch.ResolvedFQDN, powerdns.RRTypeTXT, 120, []string{key})
 
 	//First Request RRSet and check if key+value exists. else add and set as new rrset.
 	zone, err := pdns.Zones.Get(config.Zone)
@@ -251,7 +250,6 @@ func clientConfig(c *pdnsDNSProviderSolver, ch *v1alpha1.ChallengeRequest) (inte
 	if err != nil {
 		return config, err
 	}
-	config.ZoneName = cfg.ZoneName
 	config.ApiUrl = cfg.ApiUrl
 	config.ServerName = cfg.ServerName
 	config.Zone = cfg.Zone

--- a/testdata/pdns/config.json
+++ b/testdata/pdns/config.json
@@ -1,6 +1,5 @@
 {
     "secretName": "pdns-secret",
-    "zoneName": "example.com.",
     "server": "localhost",
     "apiUrl" : "https://powerdns.api"
   }


### PR DESCRIPTION
Hello,

I made two changes, I hope you find them OK. I am not a go programmer, so I just copy-pasted some of your code and modified it a bit. These are the changes:

One: I did not understand why there was a "zone" and a "zonename" setting in the config. Reading through the code gave me the impression that "zonename" was not even used, so I removed it.

Two: I would like to run this webhook on a dedicated DNS server that is only used for ACME challenges, so that I do not have to open the API on the regular DNS server. But the records on this dedicated server should be hosted under a different subdomain. To make this possible I needed a way to override the default FQDN that is passed to the webhook. So I added an optional "domain" config setting.

Regards,

Emiel Bruijntjes